### PR TITLE
Add Alphabusiness Creatio OAuth portal

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,2 +1,174 @@
-# Entry point for Flask app
+import json
+import secrets
+from urllib.parse import urlencode
 
+import requests
+from flask import Flask, session, redirect, url_for, request, render_template
+
+# Load configuration from appsettings.json
+with open('appsettings.json') as f:
+    config = json.load(f)
+
+app = Flask(__name__)
+app.secret_key = 'replace_with_secure_key'
+
+openid_config_cache = None
+
+def get_openid_configuration():
+    """Retrieve and cache the discovery document."""
+    global openid_config_cache
+    if openid_config_cache is None:
+        resp = requests.get(f"{config['CreatioBaseUrl']}/.well-known/openid-configuration")
+        resp.raise_for_status()
+        openid_config_cache = resp.json()
+    return openid_config_cache
+
+def get_auth_endpoints():
+    """Return authorize, token and revocation endpoints."""
+    if config.get('UseDiscoveryEndpoint', False):
+        data = get_openid_configuration()
+        return (
+            data['authorization_endpoint'],
+            data['token_endpoint'],
+            data.get('revocation_endpoint')
+        )
+    base = config['CreatioBaseUrl']
+    return (
+        f"{base}/0/connect/authorize",
+        f"{base}/0/connect/token",
+        f"{base}/0/connect/revocation"
+    )
+
+def get_userinfo_endpoint():
+    if config.get('UseDiscoveryEndpoint', False):
+        data = get_openid_configuration()
+        return data.get('userinfo_endpoint')
+    return f"{config['CreatioBaseUrl']}/0/connect/userinfo"
+
+@app.route('/')
+def index():
+    if 'access_token' in session:
+        return redirect(url_for('dashboard'))
+    return render_template('index.html')
+
+@app.route('/login')
+def login():
+    authorize_url, _, _ = get_auth_endpoints()
+    state = secrets.token_urlsafe(16)
+    session['oauth_state'] = state
+    params = {
+        'client_id': config['ClientId'],
+        'redirect_uri': config['RedirectUri'],
+        'response_type': 'code',
+        'scope': config['Scope'],
+        'state': state
+    }
+    return redirect(f"{authorize_url}?{urlencode(params)}")
+
+@app.route('/callback')
+def callback():
+    error = request.args.get('error')
+    if error:
+        return render_template('index.html', error=error)
+    code = request.args.get('code')
+    state = request.args.get('state')
+    if not code or state != session.get('oauth_state'):
+        return redirect(url_for('index'))
+    _, token_url, _ = get_auth_endpoints()
+    data = {
+        'client_id': config['ClientId'],
+        'client_secret': config['ClientSecret'],
+        'code': code,
+        'redirect_uri': config['RedirectUri'],
+        'grant_type': 'authorization_code',
+        'scope': config['Scope']
+    }
+    resp = requests.post(token_url, data=data)
+    resp.raise_for_status()
+    token_data = resp.json()
+    session['access_token'] = token_data.get('access_token')
+    session['refresh_token'] = token_data.get('refresh_token')
+    return redirect(url_for('dashboard'))
+
+@app.route('/dashboard')
+def dashboard():
+    access_token = session.get('access_token')
+    if not access_token:
+        return redirect(url_for('index'))
+    headers = {'Authorization': f'Bearer {access_token}'}
+    activities = []
+    user = {}
+    # Fetch user info
+    userinfo_endpoint = get_userinfo_endpoint()
+    if userinfo_endpoint:
+        try:
+            uresp = requests.get(userinfo_endpoint, headers=headers)
+            if uresp.status_code == 401:
+                return redirect(url_for('refresh'))
+            uresp.raise_for_status()
+            user = uresp.json()
+        except requests.RequestException:
+            user = {}
+    # Fetch activities
+    try:
+        aresp = requests.get(
+            f"{config['CreatioBaseUrl']}/0/odata/ActivityCollection?$top=5",
+            headers=headers
+        )
+        if aresp.status_code == 401:
+            return redirect(url_for('refresh'))
+        aresp.raise_for_status()
+        activities = aresp.json().get('value', [])
+    except requests.RequestException:
+        activities = []
+    return render_template('dashboard.html', user=user, activities=activities)
+
+@app.route('/refresh')
+def refresh():
+    refresh_token = session.get('refresh_token')
+    if not refresh_token:
+        return redirect(url_for('index'))
+    _, token_url, _ = get_auth_endpoints()
+    data = {
+        'client_id': config['ClientId'],
+        'client_secret': config['ClientSecret'],
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token,
+        'scope': config['Scope']
+    }
+    resp = requests.post(token_url, data=data)
+    if resp.status_code == 200:
+        token_data = resp.json()
+        session['access_token'] = token_data.get('access_token')
+        session['refresh_token'] = token_data.get('refresh_token', refresh_token)
+        return redirect(url_for('dashboard'))
+    session.clear()
+    return redirect(url_for('index'))
+
+@app.route('/revoke')
+def revoke():
+    refresh_token = session.get('refresh_token')
+    if not refresh_token:
+        session.clear()
+        return redirect(url_for('index'))
+    _, _, revocation_url = get_auth_endpoints()
+    data = {
+        'token': refresh_token,
+        'token_type_hint': 'refresh_token',
+        'client_id': config['ClientId'],
+        'client_secret': config['ClientSecret']
+    }
+    try:
+        requests.post(revocation_url, data=data)
+    except requests.RequestException:
+        pass
+    session.clear()
+    return redirect(url_for('index'))
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,2 +1,42 @@
-/* Minimal styling */
-body { font-family: Arial, sans-serif; }
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+.sidebar {
+  width: 200px;
+  background: #222;
+  color: #fff;
+  height: 100vh;
+  position: fixed;
+  padding: 20px;
+}
+
+.sidebar h2 {
+  margin-top: 0;
+}
+
+.sidebar a {
+  color: #fff;
+  text-decoration: none;
+  display: block;
+  padding: 8px 0;
+}
+
+.main {
+  margin-left: 220px;
+  padding: 20px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 15px;
+  background-color: #007BFF;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.error {
+  color: red;
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Alphabusiness Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <div class="sidebar">
+        <h2>ALPHABUSINESS</h2>
+        <nav>
+            <a href="{{ url_for('index') }}">Home</a>
+            <a href="#">Dashboard</a>
+            <a href="#">Reports</a>
+            <a href="#">Settings</a>
+        </nav>
+    </div>
+    <div class="main">
+        <h1>Corporate Portal</h1>
+        {% if user %}
+            <p>Logged in as {{ user.get('name') or user.get('email') }}</p>
+        {% endif %}
+        <h3>Recent Activities</h3>
+        <ul>
+            {% for act in activities %}
+                <li>{{ act.get('Title') }}</li>
+            {% else %}
+                <li>No activities found.</li>
+            {% endfor %}
+        </ul>
+        <a class="btn" href="{{ url_for('refresh') }}">Refresh Token</a>
+        <a class="btn" href="{{ url_for('logout') }}">Logout</a>
+        <a class="btn" href="{{ url_for('revoke') }}">Revoke</a>
+    </div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,2 +1,26 @@
-<!-- Homepage template -->
-<html><body><h2>Welcome to Alphabusiness</h2><a href='/login'>Connect Creatio account</a></body></html>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Alphabusiness Portal</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+    <div class="sidebar">
+        <h2>ALPHABUSINESS</h2>
+        <nav>
+            <a href="{{ url_for('index') }}">Home</a>
+            <a href="#">Dashboard</a>
+            <a href="#">Reports</a>
+            <a href="#">Settings</a>
+        </nav>
+    </div>
+    <div class="main">
+        <h1>Corporate Portal</h1>
+        <p>Connect your Creatio account to access integrated features and data.</p>
+        {% if error %}
+            <p class="error">{{ error }}</p>
+        {% endif %}
+        <a class="btn" href="{{ url_for('login') }}">Connect Creatio account</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build Flask demo portal using configuration from `appsettings.json`
- implement OAuth 2.0 Authorization Code flow for Creatio
- add pages to connect account and show activities
- add token refresh and revoke features
- style pages with sidebar layout

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_684701c7f6548325bce1d22964c5695a