### PR TITLE
Add chart titles and centered login button

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,15 +1,18 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+  display: flex;
+  min-height: 100vh;
 }
 
 .sidebar {
   width: 200px;
   background: #222;
   color: #fff;
-  height: 100vh;
-  position: fixed;
   padding: 20px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar h2 {
@@ -24,8 +27,10 @@ body {
 }
 
 .main {
-  margin-left: 220px;
+  flex: 1;
   padding: 20px;
+  display: flex;
+  flex-direction: column;
 }
 
 .btn {
@@ -40,3 +45,28 @@ body {
 .error {
   color: red;
 }
+
+.chart-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.chart-container {
+  flex: 1 1 40%;
+  min-width: 220px;
+  max-width: 260px;
+}
+
+.center-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.chart-container h3 {
+  margin: 0 0 10px;
+  text-align: center;
+  font-size: 1em;
+}
+

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,11 +1,117 @@
+Chart.register(ChartDataLabels);
+
+function createStaticCharts() {
+  const fragment = document.createDocumentFragment();
+
+  // Vacation days left chart
+  const vacationContainer = document.createElement('div');
+  vacationContainer.className = 'chart-container';
+  const vacationTitle = document.createElement('h3');
+  vacationTitle.textContent = 'Vacation Days Left';
+  vacationContainer.appendChild(vacationTitle);
+  const vacationCanvas = document.createElement('canvas');
+  vacationCanvas.id = 'vacationChart';
+  vacationContainer.appendChild(vacationCanvas);
+  fragment.appendChild(vacationContainer);
+
+  // Personal development plan tasks chart
+  const pdpContainer = document.createElement('div');
+  pdpContainer.className = 'chart-container';
+  const pdpTitle = document.createElement('h3');
+  pdpTitle.textContent = 'PDP Tasks Closed';
+  pdpContainer.appendChild(pdpTitle);
+  const pdpCanvas = document.createElement('canvas');
+  pdpCanvas.id = 'pdpChart';
+  pdpContainer.appendChild(pdpCanvas);
+  fragment.appendChild(pdpContainer);
+
+  // Bonuses by month chart
+  const bonusContainer = document.createElement('div');
+  bonusContainer.className = 'chart-container';
+  const bonusTitle = document.createElement('h3');
+  bonusTitle.textContent = 'Bonuses This Year';
+  bonusContainer.appendChild(bonusTitle);
+  const bonusCanvas = document.createElement('canvas');
+  bonusCanvas.id = 'bonusChart';
+  bonusContainer.appendChild(bonusCanvas);
+  fragment.appendChild(bonusContainer);
+
+  // Fake data for charts
+  new Chart(vacationCanvas.getContext('2d'), {
+    type: 'doughnut',
+    data: {
+      labels: ['Used', 'Left'],
+      datasets: [{
+        data: [12, 13],
+        backgroundColor: ['#FF6384', '#36A2EB']
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { datalabels: { color: '#000' } }
+    }
+  });
+
+  new Chart(pdpCanvas.getContext('2d'), {
+    type: 'pie',
+    data: {
+      labels: ['Closed', 'Open'],
+      datasets: [{
+        data: [80, 20],
+        backgroundColor: ['#4BC0C0', '#FFCE56']
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { datalabels: { color: '#000' } }
+    }
+  });
+
+  new Chart(bonusCanvas.getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+      datasets: [{
+        label: 'Bonuses',
+        data: [100, 150, 120, 200, 180, 220, 170, 190, 160, 210, 230, 250],
+        backgroundColor: 'rgba(75,192,192,0.4)',
+        borderColor: 'rgba(75,192,192,1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      },
+      plugins: {
+        datalabels: {
+          anchor: 'end',
+          align: 'top',
+          color: '#000'
+        }
+      },
+      responsive: true
+    }
+  });
+
+  return fragment;
+}
+
 function showConnect() {
   const content = document.getElementById('content');
   content.innerHTML = '';
+  const grid = document.createElement('div');
+  grid.className = 'chart-grid';
+  const container = document.createElement('div');
+  container.className = 'chart-container center-content';
   const btn = document.createElement('a');
   btn.className = 'btn';
   btn.href = '/login';
   btn.textContent = 'Connect Creatio account';
-  content.appendChild(btn);
+  container.appendChild(btn);
+  grid.appendChild(container);
+  grid.appendChild(createStaticCharts());
+  content.appendChild(grid);
 }
 
 function showDashboard(data) {
@@ -17,9 +123,19 @@ function showDashboard(data) {
     info.textContent = 'Logged in as ' + name;
     content.appendChild(info);
   }
+  const grid = document.createElement('div');
+  grid.className = 'chart-grid';
+  const activityContainer = document.createElement('div');
+  activityContainer.className = 'chart-container';
+  const actTitle = document.createElement('h3');
+  actTitle.textContent = 'Activities by Month';
+  activityContainer.appendChild(actTitle);
   const canvas = document.createElement('canvas');
   canvas.id = 'activityChart';
-  content.appendChild(canvas);
+  activityContainer.appendChild(canvas);
+  grid.appendChild(activityContainer);
+  grid.appendChild(createStaticCharts());
+  content.appendChild(grid);
 
   if (data.activities && data.activities.length) {
     const list = document.createElement('ul');
@@ -49,6 +165,13 @@ function showDashboard(data) {
     options: {
       scales: {
         y: { beginAtZero: true }
+      },
+      plugins: {
+        datalabels: {
+          anchor: 'end',
+          align: 'top',
+          color: '#000'
+        }
       }
     }
   });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,7 +4,7 @@
     <title>Alphabusiness Dashboard</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
-<body>
+<body class="layout">
     <div class="sidebar">
         <h2>ALPHABUSINESS</h2>
         <nav>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,10 +5,11 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
     <script defer src="{{ url_for('static', filename='js/app.js') }}"></script>
 
 </head>
-<body>
+<body class="layout">
     <div class="sidebar">
         <h2>ALPHABUSINESS</h2>
         <nav>


### PR DESCRIPTION
## Summary
- make charts smaller with titles and datalabels
- center the OAuth button within its grid cell
- load chartjs datalabels plugin for value labels

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_684eb26d3b688325a2f9dd8290d8de24