### PR TITLE
Fix OAuth redirect and rearrange charts

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,15 +1,18 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+  display: flex;
+  min-height: 100vh;
 }
 
 .sidebar {
   width: 200px;
   background: #222;
   color: #fff;
-  height: 100vh;
-  position: fixed;
   padding: 20px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar h2 {
@@ -24,8 +27,10 @@ body {
 }
 
 .main {
-  margin-left: 220px;
+  flex: 1;
   padding: 20px;
+  display: flex;
+  flex-direction: column;
 }
 
 .btn {
@@ -40,3 +45,27 @@ body {
 .error {
   color: red;
 }
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.chart-container {
+  min-width: 220px;
+  max-width: 260px;
+}
+
+.center-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.chart-container h3 {
+  margin: 0 0 10px;
+  text-align: center;
+  font-size: 1em;
+}
+

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,11 +1,117 @@
+Chart.register(ChartDataLabels);
+
+function createBonusChart() {
+  const container = document.createElement('div');
+  container.className = 'chart-container';
+  const title = document.createElement('h3');
+  title.textContent = 'Bonuses This Year';
+  container.appendChild(title);
+  const canvas = document.createElement('canvas');
+  canvas.id = 'bonusChart';
+  container.appendChild(canvas);
+
+  new Chart(canvas.getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+      datasets: [{
+        label: 'Bonuses',
+        data: [100, 150, 120, 200, 180, 220, 170, 190, 160, 210, 230, 250],
+        backgroundColor: 'rgba(75,192,192,0.4)',
+        borderColor: 'rgba(75,192,192,1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      },
+      plugins: {
+        datalabels: {
+          anchor: 'end',
+          align: 'top',
+          color: '#000'
+        }
+      },
+      responsive: true
+    }
+  });
+
+  return container;
+}
+
+function createVacationChart() {
+  const container = document.createElement('div');
+  container.className = 'chart-container';
+  const title = document.createElement('h3');
+  title.textContent = 'Vacation Days Left';
+  container.appendChild(title);
+  const canvas = document.createElement('canvas');
+  canvas.id = 'vacationChart';
+  container.appendChild(canvas);
+
+  new Chart(canvas.getContext('2d'), {
+    type: 'doughnut',
+    data: {
+      labels: ['Used', 'Left'],
+      datasets: [{
+        data: [12, 13],
+        backgroundColor: ['#FF6384', '#36A2EB']
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { datalabels: { color: '#000' } }
+    }
+  });
+
+  return container;
+}
+
+function createPdpChart() {
+  const container = document.createElement('div');
+  container.className = 'chart-container';
+  const title = document.createElement('h3');
+  title.textContent = 'PDP Tasks Closed';
+  container.appendChild(title);
+  const canvas = document.createElement('canvas');
+  canvas.id = 'pdpChart';
+  container.appendChild(canvas);
+
+  new Chart(canvas.getContext('2d'), {
+    type: 'pie',
+    data: {
+      labels: ['Closed', 'Open'],
+      datasets: [{
+        data: [80, 20],
+        backgroundColor: ['#4BC0C0', '#FFCE56']
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { datalabels: { color: '#000' } }
+    }
+  });
+  return container;
+}
+
 function showConnect() {
   const content = document.getElementById('content');
   content.innerHTML = '';
+  const grid = document.createElement('div');
+  grid.className = 'chart-grid';
+  grid.appendChild(createBonusChart());
+  const btnContainer = document.createElement('div');
+  btnContainer.className = 'chart-container center-content';
   const btn = document.createElement('a');
   btn.className = 'btn';
-  btn.href = '/login';
+  btn.href = window.LOGIN_URL || '/login';
   btn.textContent = 'Connect Creatio account';
-  content.appendChild(btn);
+  btnContainer.appendChild(btn);
+  grid.appendChild(btnContainer);
+  grid.appendChild(createVacationChart());
+  grid.appendChild(createPdpChart());
+  content.appendChild(grid);
 }
 
 function showDashboard(data) {
@@ -17,9 +123,21 @@ function showDashboard(data) {
     info.textContent = 'Logged in as ' + name;
     content.appendChild(info);
   }
+  const grid = document.createElement('div');
+  grid.className = 'chart-grid';
+  grid.appendChild(createBonusChart());
+  const activityContainer = document.createElement('div');
+  activityContainer.className = 'chart-container';
+  const actTitle = document.createElement('h3');
+  actTitle.textContent = 'Activities by Month';
+  activityContainer.appendChild(actTitle);
   const canvas = document.createElement('canvas');
   canvas.id = 'activityChart';
-  content.appendChild(canvas);
+  activityContainer.appendChild(canvas);
+  grid.appendChild(activityContainer);
+  grid.appendChild(createVacationChart());
+  grid.appendChild(createPdpChart());
+  content.appendChild(grid);
 
   if (data.activities && data.activities.length) {
     const list = document.createElement('ul');
@@ -49,6 +167,13 @@ function showDashboard(data) {
     options: {
       scales: {
         y: { beginAtZero: true }
+      },
+      plugins: {
+        datalabels: {
+          anchor: 'end',
+          align: 'top',
+          color: '#000'
+        }
       }
     }
   });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,7 +4,7 @@
     <title>Alphabusiness Dashboard</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
-<body>
+<body class="layout">
     <div class="sidebar">
         <h2>ALPHABUSINESS</h2>
         <nav>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,10 +5,14 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
     <script defer src="{{ url_for('static', filename='js/app.js') }}"></script>
+    <script>
+        window.LOGIN_URL = "{{ url_for('login') }}";
+    </script>
 
 </head>
-<body>
+<body class="layout">
     <div class="sidebar">
         <h2>ALPHABUSINESS</h2>
         <nav>


### PR DESCRIPTION
## Summary
- use grid layout for charts and login button
- define LOGIN_URL in index template and reference in JS
- create individual chart builders and rearrange chart order

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_684eb26d3b688325a2f9dd8290d8de24