### PR TITLE
Implement Auth0 login and protect pages

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1,8 +1,12 @@
 {
   "ClientId": "your_client_id",
   "ClientSecret": "your_client_secret",
-  "RedirectUri": "http://localhost:5000/callback",
+  "RedirectUri": "http://localhost:5000/creatio/callback",
   "CreatioBaseUrl": "https://your-creatio.com",
   "Scope": "offline_access ApplicationAccess_XXXX",
-  "UseDiscoveryEndpoint": true
+  "UseDiscoveryEndpoint": true,
+  "Auth0Domain": "your-auth0-domain",
+  "Auth0ClientId": "your-auth0-client-id",
+  "Auth0ClientSecret": "your-auth0-client-secret",
+  "Auth0CallbackUri": "http://localhost:5000/auth/callback"
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -105,7 +105,7 @@ function showConnect() {
   btnContainer.className = 'chart-container center-content';
   const btn = document.createElement('a');
   btn.className = 'btn';
-  btn.href = window.LOGIN_URL || '/login';
+  btn.href = window.LOGIN_URL || '/creatio/login';
   btn.textContent = 'Connect Creatio account';
   btnContainer.appendChild(btn);
   grid.appendChild(btnContainer);


### PR DESCRIPTION
## Summary
- add Auth0 configuration options
- create Auth0 login/callback routes
- add `login_required` decorator and protect existing routes
- rename Creatio login endpoints
- update JS constant for new login URL
- clear Auth0 session info on logout

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_6856ca922cac8325955299731b151440