### PR TITLE
Implement custom login

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -74,3 +74,13 @@ body {
   font-size: 1em;
 }
 
+.login-box {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 300px;
+}
+.login-box input {
+  padding: 8px;
+}
+

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body class="center-content" style="height:100vh;">
+    <form method="post" class="login-box">
+        <h2>Login</h2>
+        {% if error %}<p class="error">{{ error }}</p>{% endif %}
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
+        <button type="submit" class="btn">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace Auth0 with custom username/password login
- store users and Creatio tokens in SQLite database
- issue signed JWTs for authenticated sessions
- add login page and basic styling

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_6856d21f34708325ba824576a3751301