### PR TITLE
Add header and loading mask to frontend

### DIFF
--- a/app.py
+++ b/app.py
@@ -239,7 +239,12 @@ def login():
 @login_required
 def index():
     login_url = build_login_url()
-    return render_template('index.html', login_url=login_url)
+    return render_template(
+        'index.html',
+        login_url=login_url,
+        user_id=g.user['id'],
+        username=g.user['username']
+    )
 
 
 @app.route('/creatio/login')
@@ -323,7 +328,16 @@ def api_activities():
             continue
         month = date_str[:7]
         counts[month] = counts.get(month, 0) + 1
-    return jsonify({'authenticated': True, 'user': user, 'activities': activities, 'counts': counts})
+    return jsonify({
+        'authenticated': True,
+        'user': user,
+        'activities': activities,
+        'counts': counts,
+        'localUser': {
+            'id': g.user['id'],
+            'username': g.user['username']
+        }
+    })
 
 @app.route('/refresh')
 @login_required

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -48,7 +48,7 @@ body {
 
 .chart-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 20px;
   width: 100%;
 }
@@ -82,5 +82,58 @@ body {
 }
 .login-box input {
   padding: 8px;
+}
+
+.top-panel {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.user-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.user-menu {
+  position: absolute;
+  top: 50px;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 5px 10px;
+  display: none;
+  z-index: 100;
+}
+
+.user-menu.show {
+  display: block;
+}
+
+.preloader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.preloader.hidden {
+  display: none;
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -15,6 +15,7 @@
         </nav>
     </div>
     <div class="main">
+        <div id="top-panel" class="top-panel"></div>
         <h1>Corporate Portal</h1>
         {% if user %}
             <p>Logged in as {{ user.get('name') or user.get('email') }}</p>
@@ -27,9 +28,8 @@
                 <li>No activities found.</li>
             {% endfor %}
         </ul>
-        <a class="btn" href="{{ url_for('refresh') }}">Refresh Token</a>
         <a class="btn" href="{{ url_for('logout') }}">Logout</a>
-        <a class="btn" href="{{ url_for('revoke') }}">Revoke</a>
     </div>
+    <div id="preloader" class="preloader hidden">Loading...</div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,7 @@
     <script defer src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script>
         window.LOGIN_URL = {{ login_url|tojson|safe }};
+        window.LOCAL_USER = {{ {'id': user_id, 'username': username}|tojson|safe }};
     </script>
 
 </head>
@@ -27,11 +28,13 @@
         </nav>
     </div>
     <div class="main">
+        <div id="top-panel" class="top-panel"></div>
         <h1>Home page</h1>
         <p>Connect your Creatio account to access integrated features and data.</p>
 
         <div id="content"></div>
 
     </div>
+    <div id="preloader" class="preloader hidden">Loading...</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add top panel with avatar generated from username and ID
- remove token action links and show logout in top menu instead
- display loading mask while requesting data
- return local user info from API
- restore two-column chart grid

## Testing
- `python -m py_compile app.py`
- *(fails: requests module missing)*

------
https://chatgpt.com/codex/tasks/task_b_6856dae42b688325844dc180469ad866