### PR TITLE
Improve dashboard layout and styling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -51,15 +51,19 @@ body {
   grid-template-columns: repeat(2, 1fr);
   gap: 20px;
   width: 100%;
+  grid-auto-rows: minmax(0, 400px);
 }
 
 .chart-container {
   width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .chart-container canvas {
   width: 100% !important;
-  height: auto !important;
+  flex: 1 1 auto;
 }
 
 .center-content {
@@ -152,5 +156,12 @@ body {
 
 .preloader.hidden {
   display: none;
+}
+
+.logo-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 5px;
+  vertical-align: middle;
 }
 

--- a/static/img/creatio-logo.svg
+++ b/static/img/creatio-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="12" fill="#f36f21"/>
+  <text x="12" y="16" text-anchor="middle" font-size="12" fill="white" font-family="Arial, sans-serif">C</text>
+</svg>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -171,7 +171,7 @@ function showConnect() {
   const btn = document.createElement('a');
   btn.className = 'btn';
   btn.href = window.LOGIN_URL || '/creatio/login';
-  btn.textContent = 'Connect Creatio account';
+  btn.innerHTML = '<img src="/static/img/creatio-logo.svg" class="logo-icon" alt="Creatio"> Connect Creatio account';
   btnContainer.appendChild(btn);
   const desc = document.createElement('p');
   desc.textContent = 'Connect your Creatio account to access integrated features and data.';
@@ -231,8 +231,8 @@ function showDashboard(data) {
       datasets: [{
         label: 'Activities by Month',
         data: values,
-        backgroundColor: 'rgba(75,192,192,0.4)',
-        borderColor: 'rgba(75,192,192,1)',
+        backgroundColor: 'rgba(255,165,0,0.4)',
+        borderColor: 'rgba(255,165,0,1)',
         borderWidth: 1
       }]
     },


### PR DESCRIPTION
## Summary
- resize grid rows to max 400px to make pie charts consistent
- add flex layout for chart containers
- add Creatio logo to connect button
- color Creatio data chart in orange
- include Creatio logo asset

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6857c6097f988325815942605b0340fb