### PR TITLE
Improve pie chart handling and update fonts

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
+  font-family: 'Montserrat', Arial, sans-serif;
   display: flex;
   min-height: 100vh;
 }
@@ -51,15 +53,38 @@ body {
   grid-template-columns: repeat(2, 1fr);
   gap: 20px;
   width: 100%;
+  grid-auto-rows: minmax(0, 400px);
 }
 
 .chart-container {
   width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .chart-container canvas {
   width: 100% !important;
   height: auto !important;
+}
+
+.pie-container {
+  align-items: center;
+}
+
+.pie-wrapper {
+  width: 100%;
+  max-width: 400px;
+  aspect-ratio: 1;
+  margin: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pie-wrapper canvas {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .center-content {
@@ -152,5 +177,12 @@ body {
 
 .preloader.hidden {
   display: none;
+}
+
+.logo-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 5px;
+  vertical-align: middle;
 }
 

--- a/static/img/creatio-logo.svg
+++ b/static/img/creatio-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="12" fill="#f36f21"/>
+  <text x="12" y="16" text-anchor="middle" font-size="12" fill="white" font-family="Arial, sans-serif">C</text>
+</svg>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -107,13 +107,16 @@ function createBonusChart() {
 
 function createVacationChart() {
   const container = document.createElement('div');
-  container.className = 'chart-container';
+  container.className = 'chart-container pie-container';
   const title = document.createElement('h3');
   title.textContent = 'Vacation Days Left';
   container.appendChild(title);
+  const wrapper = document.createElement('div');
+  wrapper.className = 'pie-wrapper';
   const canvas = document.createElement('canvas');
   canvas.id = 'vacationChart';
-  container.appendChild(canvas);
+  wrapper.appendChild(canvas);
+  container.appendChild(wrapper);
 
   new Chart(canvas.getContext('2d'), {
     type: 'doughnut',
@@ -126,6 +129,7 @@ function createVacationChart() {
     },
     options: {
       responsive: true,
+      aspectRatio: 1,
       plugins: { datalabels: { color: '#000' } }
     }
   });
@@ -135,13 +139,16 @@ function createVacationChart() {
 
 function createPdpChart() {
   const container = document.createElement('div');
-  container.className = 'chart-container';
+  container.className = 'chart-container pie-container';
   const title = document.createElement('h3');
   title.textContent = 'PDP Tasks Closed';
   container.appendChild(title);
+  const wrapper = document.createElement('div');
+  wrapper.className = 'pie-wrapper';
   const canvas = document.createElement('canvas');
   canvas.id = 'pdpChart';
-  container.appendChild(canvas);
+  wrapper.appendChild(canvas);
+  container.appendChild(wrapper);
 
   new Chart(canvas.getContext('2d'), {
     type: 'pie',
@@ -154,6 +161,7 @@ function createPdpChart() {
     },
     options: {
       responsive: true,
+      aspectRatio: 1,
       plugins: { datalabels: { color: '#000' } }
     }
   });
@@ -171,7 +179,7 @@ function showConnect() {
   const btn = document.createElement('a');
   btn.className = 'btn';
   btn.href = window.LOGIN_URL || '/creatio/login';
-  btn.textContent = 'Connect Creatio account';
+  btn.innerHTML = '<img src="/static/img/creatio-logo.svg" class="logo-icon" alt="Creatio"> Connect Creatio account';
   btnContainer.appendChild(btn);
   const desc = document.createElement('p');
   desc.textContent = 'Connect your Creatio account to access integrated features and data.';
@@ -231,8 +239,8 @@ function showDashboard(data) {
       datasets: [{
         label: 'Activities by Month',
         data: values,
-        backgroundColor: 'rgba(75,192,192,0.4)',
-        borderColor: 'rgba(75,192,192,1)',
+        backgroundColor: 'rgba(255,165,0,0.4)',
+        borderColor: 'rgba(255,165,0,1)',
         borderWidth: 1
       }]
     },


### PR DESCRIPTION
## Summary
- load Montserrat font and use it across the site
- add `.pie-wrapper` to keep pie charts square and centered
- wrap pie canvases in the new wrapper

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6857c6097f988325815942605b0340fb