### PR TITLE
Improve call charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -314,7 +314,7 @@ def dashboard():
 @app.route('/api/activities')
 @login_required
 def api_activities():
-    """Return user info, activities and monthly counts as JSON."""
+    """Return user info, activities and daily counts as JSON."""
     if not g.user['creatio_access_token']:
         return jsonify({'authenticated': False}), 401
     result = fetch_user_and_activities()
@@ -326,8 +326,8 @@ def api_activities():
         date_str = act.get('StartDate') or act.get('CreatedOn')
         if not date_str:
             continue
-        month = date_str[:7]
-        counts[month] = counts.get(month, 0) + 1
+        day = date_str[:10]
+        counts[day] = counts.get(day, 0) + 1
     return jsonify({
         'authenticated': True,
         'user': user,

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -98,6 +98,7 @@ function createBonusChart() {
           color: '#000'
         }
       },
+      layout: { padding: { bottom: 24 } },
       responsive: true
     }
   });
@@ -130,7 +131,8 @@ function createVacationChart() {
     options: {
       responsive: true,
       aspectRatio: 1,
-      plugins: { datalabels: { color: '#000' } }
+      plugins: { datalabels: { color: '#000' } },
+      layout: { padding: { bottom: 24 } }
     }
   });
 
@@ -162,7 +164,8 @@ function createPdpChart() {
     options: {
       responsive: true,
       aspectRatio: 1,
-      plugins: { datalabels: { color: '#000' } }
+      plugins: { datalabels: { color: '#000' } },
+      layout: { padding: { bottom: 24 } }
     }
   });
   return container;
@@ -209,35 +212,25 @@ function showDashboard(data) {
   const activityContainer = document.createElement('div');
   activityContainer.className = 'chart-container';
   const actTitle = document.createElement('h3');
-  actTitle.textContent = 'Activities by Month';
+  actTitle.textContent = 'Calls by Date';
   activityContainer.appendChild(actTitle);
   const canvas = document.createElement('canvas');
-  canvas.id = 'activityChart';
+  canvas.id = 'callsChart';
   activityContainer.appendChild(canvas);
   grid.appendChild(activityContainer);
   grid.appendChild(createVacationChart());
   grid.appendChild(createPdpChart());
   content.appendChild(grid);
 
-  if (data.activities && data.activities.length) {
-    const list = document.createElement('ul');
-    data.activities.forEach(a => {
-      const li = document.createElement('li');
-      li.textContent = a.Title;
-      list.appendChild(li);
-    });
-    content.appendChild(list);
-  }
-
   const labels = Object.keys(data.counts).sort();
   const values = labels.map(l => data.counts[l]);
 
-  new Chart(document.getElementById('activityChart').getContext('2d'), {
+  new Chart(document.getElementById('callsChart').getContext('2d'), {
     type: 'bar',
     data: {
       labels: labels,
       datasets: [{
-        label: 'Activities by Month',
+        label: 'Calls',
         data: values,
         backgroundColor: 'rgba(255,165,0,0.4)',
         borderColor: 'rgba(255,165,0,1)',
@@ -254,7 +247,8 @@ function showDashboard(data) {
           align: 'top',
           color: '#000'
         }
-      }
+      },
+      layout: { padding: { bottom: 24 } }
     }
   });
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -21,14 +21,7 @@
         {% if user %}
             <p>Logged in as {{ user.get('name') or user.get('email') }}</p>
         {% endif %}
-        <h3>Recent Activities</h3>
-        <ul>
-            {% for act in activities %}
-                <li>{{ act.get('Title') }}</li>
-            {% else %}
-                <li>No activities found.</li>
-            {% endfor %}
-        </ul>
+        
     </div>
     <div id="preloader" class="preloader hidden">Loading...</div>
 </body>


### PR DESCRIPTION
## Summary
- improve spacing between chart legend and data
- rename activities to calls in UI
- show call counts per day instead of per month
- remove activity titles from the dashboard template

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_6857e0bbcc7c8325a630c55e599805d5