### PR TITLE
Refine Creatio logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ import time
 import sqlite3
 
 import requests
+import logging
 
 from flask import Flask, redirect, url_for, request, render_template, jsonify, g, session
 
@@ -27,6 +28,14 @@ with open('appsettings.json') as f:
 
 app = Flask(__name__)
 app.secret_key = 'replace_with_secure_key'
+
+# Configure logging to write Creatio request info to a file with timestamps
+logging.basicConfig(
+    level=logging.INFO,
+    filename='creatio_token_requests.log',
+    format='%(asctime)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
 
 DATABASE = 'users.db'
 
@@ -61,6 +70,29 @@ def init_db():
 
 
 init_db()
+
+
+def creatio_request(method: str, url: str, log=False, **kwargs):
+    """Make an HTTP request to Creatio and optionally log the URL and response."""
+    if log:
+        logger.info("Request URL: %s", url)
+    try:
+        response = requests.request(method, url, **kwargs)
+        if log:
+            logger.info("Response body: %s", response.text)
+        return response
+    except requests.RequestException as exc:
+        if log:
+            logger.info("Request to %s failed: %s", url, exc)
+        raise
+
+
+def creatio_get(url: str, log=False, **kwargs):
+    return creatio_request("GET", url, log=log, **kwargs)
+
+
+def creatio_post(url: str, log=False, **kwargs):
+    return creatio_request("POST", url, log=log, **kwargs)
 
 
 def clear_tokens(user_id):
@@ -133,7 +165,7 @@ def get_openid_configuration():
     global openid_config_cache
     if openid_config_cache is None:
         try:
-            resp = requests.get(
+            resp = creatio_get(
                 f"{config['CreatioBaseUrl']}/.well-known/openid-configuration",
                 timeout=5,
             )
@@ -160,15 +192,6 @@ def get_auth_endpoints():
         f"{base}/0/connect/revocation",
     )
 
-def get_userinfo_endpoint():
-    if config.get('UseDiscoveryEndpoint', False):
-        data = get_openid_configuration() or {}
-        endpoint = data.get('userinfo_endpoint')
-        if endpoint:
-            return endpoint
-    return f"{config['CreatioBaseUrl']}/0/connect/userinfo"
-
-
 def fetch_user_and_activities():
     """Retrieve user info and recent activities using current access token."""
     access_token = g.user['creatio_access_token']
@@ -178,20 +201,9 @@ def fetch_user_and_activities():
     headers = {'Authorization': f'Bearer {access_token}'}
     user = None
     activities = []
-    userinfo_endpoint = get_userinfo_endpoint()
-    if userinfo_endpoint:
-        try:
-            resp = requests.get(userinfo_endpoint, headers=headers)
-            if resp.status_code == 401:
-                return 'refresh', []
-            resp.raise_for_status()
-            user = resp.json()
-        except requests.RequestException:
-            user = None
     try:
-        aresp = requests.get(
+        aresp = creatio_get(
             f"{config['CreatioBaseUrl']}/0/odata/Activity?$top=50",
-
             headers=headers
         )
         if aresp.status_code == 401:
@@ -275,7 +287,7 @@ def creatio_callback():
         'scope': config['Scope']
     }
     try:
-        resp = requests.post(token_url, data=data, timeout=5)
+        resp = creatio_post(token_url, data=data, timeout=5, log=True)
         resp.raise_for_status()
         token_data = resp.json()
     except requests.RequestException:
@@ -355,7 +367,7 @@ def refresh():
         'scope': config['Scope']
     }
     try:
-        resp = requests.post(token_url, data=data, timeout=5)
+        resp = creatio_post(token_url, data=data, timeout=5, log=True)
         if resp.status_code == 200:
             token_data = resp.json()
             conn = get_db_connection()
@@ -392,7 +404,7 @@ def revoke():
         'client_secret': config['ClientSecret']
     }
     try:
-        requests.post(revocation_url, data=data)
+        creatio_post(revocation_url, data=data)
     except requests.RequestException:
         pass
 


### PR DESCRIPTION
## Summary
- log only token and refresh requests
- write Creatio request logs to a `creatio_token_requests.log` file
- drop calls to the nonexistent `/connect/userinfo` endpoint

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6857f28fbe488325b9e21b858f7ddcf2